### PR TITLE
Add feature to seek to relative file position

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -12,3 +12,4 @@
 * CALL
 * SWAP
 * Manually specify AMCP command
+* Goto relative position (from start or end of video)

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var log;
 function instance(system, id, config) {
 	var self = this;
 
-	self.multiline_callback = {};
-	self.multiline_current = '';
+	self.response_callback = {};
+	self.response_current = '';
 
 	self.CHOICES_TEMPLATES = [];
 	self.CHOICES_MEDIAFILES = [];
@@ -100,8 +100,8 @@ instance.prototype.init_tcp = function() {
 		self.socket.on('connect', function () {
 			debug("Connected");
 
-			self.requestMultilineData("CLS", self.handleCLS.bind(self));
-			self.requestMultilineData("TLS", self.handleTLS.bind(self));
+			self.requestData("CLS", null, self.handleCLS.bind(self));
+			self.requestData("TLS", null, self.handleTLS.bind(self));
 		});
 
 		var receivebuffer = '';
@@ -169,12 +169,13 @@ instance.prototype.init_tcp = function() {
 					case RETCODE.INFODATA:
 					case RETCODE.OKDATA:
 						self.acmp_state = ACMP_STATE.SINGLE_LINE;
+						self.response_current = status;
 						self.error_code = undefined;
 						break;
 
 					case RETCODE.OKMULTIDATA:
 						self.acmp_state = ACMP_STATE.MULTI_LINE;
-						self.multiline_current = status;
+						self.response_current = status;
 						self.error_code = undefined;
 						self.multilinedata = [];
 						break;
@@ -195,6 +196,17 @@ instance.prototype.init_tcp = function() {
 
 				if (self.error_code !== undefined) {
 					self.log('error', 'Got error ' + RETCODE2TYPE[self.error_code] + ': ' + line);
+				} else {
+					self.response_current = self.response_current.toUpperCase();
+
+					if (self.response_callback[self.response_current] !== undefined && self.response_callback[self.response_current].length) {
+						var cb = self.response_callback[self.response_current].shift();
+
+						if (typeof cb == 'function') {
+							cb(line);
+							self.response_current = '';
+						}
+					}
 				}
 			}
 
@@ -204,15 +216,15 @@ instance.prototype.init_tcp = function() {
 				if (line == '') {
 					self.acmp_state = ACMP_STATE.NEXT;
 
-					self.multiline_current = self.multiline_current.toUpperCase();
+					self.response_current = self.response_current.toUpperCase();
 
-					if (self.multiline_callback[self.multiline_current] !== undefined && self.multiline_callback[self.multiline_current].length) {
-						var cb = self.multiline_callback[self.multiline_current].shift();
+					if (self.response_callback[self.response_current] !== undefined && self.response_callback[self.response_current].length) {
+						var cb = self.response_callback[self.response_current].shift();
 
 						if (typeof cb == 'function') {
 							cb(self.multilinedata);
 							self.multilinedata.length = 0;
-							self.multiline_current = '';
+							self.response_current = '';
 						}
 					}
 				} else {
@@ -646,19 +658,23 @@ function esc(str) {
 	return str.replace(/"/g, "&quot;");
 }
 
-instance.prototype.requestMultilineData = function(command, callback) {
+instance.prototype.requestData = function(command, params, callback) {
 	var self = this;
 
 	if (self.socket !== undefined && self.socket.connected) {
 		command = command.toUpperCase();
 
-		if (self.multiline_callback[command] === undefined) {
-			self.multiline_callback[command] = [];
+		if (self.response_callback[command] === undefined) {
+			self.response_callback[command] = [];
 		}
 
-		self.multiline_callback[command].push(callback);
+		self.response_callback[command].push(callback);
 
-		self.socket.send(command + "\r\n");
+		out = command
+		if (params && params.length) {
+			out += ' ' + params
+		}
+		self.socket.send(out + "\r\n");
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "Håkon Nessjøen <haakon@bitfocus.io>",
-	"license": "ISC"
+	"license": "ISC",
+	"dependencies": {
+		"xml2js": "^0.4.19"
+	}
 }


### PR DESCRIPTION
This PR adds a new action to seek to relative file positions.
We use this regularly during rehearsals / run-throughs to skip to e.g. 10 seconds before the end of a video.

Tested with Caspar CG 2.2.0
The added dependency is already used by other modules.